### PR TITLE
Add _ViewStart.cshtml

### DIFF
--- a/src/Chirp.Web/Pages/_ViewStart.cshtml
+++ b/src/Chirp.Web/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}


### PR DESCRIPTION
Fix missing navigation bar on Azure deployment by adding _ViewStart.cshtml to ensure layout is applied to all pages